### PR TITLE
Issue #27 -- Crash in MockSensorTest.DeletedListener in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ ADD build.sh /opt/thermocouple/
 WORKDIR /opt/thermocouple
 
 # build and test the app
-CMD [ "./build.sh", "build", "release" ]
+CMD [ "./build.sh", "test", "release" ]


### PR DESCRIPTION
* Stop deleting subscriptions while looping over them. This invalidates the iterator being deleted, which prevents us from iterating to the next item, even when using a range-for loop.