### PR TITLE
Issue #31 -- Use pre-built Docker image to speed CI builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,6 @@
-# docker build -t thermocouple-build . && docker run thermocouple-build
-FROM ubuntu:18.04
+# docker build -t thermocouple-build . && docker run --rm thermocouple-build
+FROM kilpatjr/thermocouple-build-base
 MAINTAINER Jeff Kilpatrick <jeff@bouncingsheep.org>
-
-# install system-wide deps
-RUN apt-get -yqq update
-RUN apt-get -yqq install cmake curl file g++ libncurses5-dev libusb-dev
-
-WORKDIR /opt/phidgets21
-RUN curl -O https://www.phidgets.com/downloads/phidget21/libraries/linux/libphidget/libphidget_2.1.9.20190409.tar.gz
-RUN tar -xzf libphidget_2.1.9.20190409.tar.gz
-WORKDIR /opt/phidgets21/libphidget-2.1.9.20190409
-RUN ./configure
-RUN make install
 
 # copy our sources
 ADD cmake    /opt/thermocouple/cmake

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,14 @@
+# docker build -t thermocouple-build-base -f Dockerfile.base .
+FROM ubuntu:18.04
+MAINTAINER Jeff Kilpatrick <jeff@bouncingsheep.org>
+
+# install system-wide deps
+RUN apt-get -yqq update
+RUN apt-get -yqq install cmake curl file g++ libncurses5-dev libusb-dev
+
+WORKDIR /opt/phidgets21
+RUN curl -O https://www.phidgets.com/downloads/phidget21/libraries/linux/libphidget/libphidget_2.1.9.20190409.tar.gz
+RUN tar -xzf libphidget_2.1.9.20190409.tar.gz
+WORKDIR /opt/phidgets21/libphidget-2.1.9.20190409
+RUN ./configure
+RUN make install


### PR DESCRIPTION
* Deploy Deploy an image with everything needed to build Thermocouple to Docker Hub.
* Use this pre-built image to build Thermocouple